### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"      # Location of your workflow files
+    schedule:
+      interval: "weekly"  # Options: daily, weekly, monthly

--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3
         uses: actions/setup-python@v1

--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run asv
         run: |
           asv machine --yes
-          asv dev
+          asv run
 
       - name: Check benchmarks.json is up to date
         run: |

--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -1,6 +1,8 @@
 # This workflow checks that any added benchmarks *run* on the latest Matplotlib
 # release. It does _not_ update any results.
 name: Benchmark Check
+permissions:
+  contents: read
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/asv.yml
+++ b/.github/workflows/asv.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install asv
         run: pip3 install asv matplotlib

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,6 @@
 name: GitHub Pages
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,7 +23,7 @@ jobs:
         run: asv publish
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./html

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3
         uses: actions/setup-python@v1

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3
         uses: actions/setup-python@v1

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,4 +1,6 @@
 name: Linting
+permissions:
+  contents: read
 on: [pull_request]
 
 jobs:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install flake8
         run: pip3 install flake8


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions
- adding a depandabot file for GHA
